### PR TITLE
WQP-1266 Create mechanism for dropping organization from STORETW ETL

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,5 +1,7 @@
 <project name="QwStoretEtl" default="weeklyETL">
     <property name="work.dir" value="/mnt/wqp_data/${instance}" />
+
+    <target name="storetwTransition" depends="buildPackageStage, runWeeklyPackageStage" />
     
     <target name="weeklyETL" depends="buildPackageStage, scpScriptStage, dos2unixStage, pullStoretWData, weeklyImportViaDataPump, grantsOnStoretWTables, runWeeklyPackageStage, finishETL" />
 

--- a/create_storet_objects_stage.sql
+++ b/create_storet_objects_stage.sql
@@ -72,8 +72,8 @@ create or replace package body create_storet_objects as
                                       on fk_mad_vmethod = lu_mad_vmethod.pk_isn
                                     left join storetw.lu_mad_vdatum
                                       on fk_mad_vdatum = lu_mad_vdatum.pk_isn
-                              where storetw.fa_station.location_point_type = '*POINT OF RECORD'!
-                                    and storetw.fa_station.organization_id not in(select org_id from wqp_core.storetw_transition);
+                              where storetw.fa_station.location_point_type = '*POINT OF RECORD'
+                                    and storetw.fa_station.organization_id not in(select org_id from wqp_core.storetw_transition)!';
         commit;
     end create_station_no_source;
 

--- a/create_storet_objects_stage.sql
+++ b/create_storet_objects_stage.sql
@@ -72,7 +72,8 @@ create or replace package body create_storet_objects as
                                       on fk_mad_vmethod = lu_mad_vmethod.pk_isn
                                     left join storetw.lu_mad_vdatum
                                       on fk_mad_vdatum = lu_mad_vdatum.pk_isn
-                              where storetw.fa_station.location_point_type = '*POINT OF RECORD'!';
+                              where storetw.fa_station.location_point_type = '*POINT OF RECORD'!
+                                    and storetw.fa_station.organization_id not in(select org_id from wqp_core.storetw_transition);
         commit;
     end create_station_no_source;
 


### PR DESCRIPTION
WQP-1266 Create mechanism for dropping organization from STORETW ETL

Adds an additional 'and' to the 'where' clause to exclude organisational ids in the
table o' ids to exclude, and two additional build targets.