### PR TITLE
WQP-1410 - STORETW Data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,50 +146,6 @@
                                 <ports>
                                     <port>5437:5432</port>
                                 </ports>
-                                <env>
-                                    <CONTEXTS>external,ci,schemaLoad</CONTEXTS>
-                                    <POSTGRES_PASSWORD>changeMe</POSTGRES_PASSWORD>
-                                    <WQP_DATABASE_ADDRESS>127.0.0.1</WQP_DATABASE_ADDRESS>
-                                    <WQP_DATABASE_NAME>wqp_db</WQP_DATABASE_NAME>
-                                    <WQP_DB_OWNER_USERNAME>wqp_core</WQP_DB_OWNER_USERNAME>
-                                    <WQP_DB_OWNER_PASSWORD>changeMe</WQP_DB_OWNER_PASSWORD>
-                                    <WQP_SCHEMA_NAME>wqp</WQP_SCHEMA_NAME>
-                                    <WQP_SCHEMA_OWNER_USERNAME>wqp_core</WQP_SCHEMA_OWNER_USERNAME>
-                                    <WQP_SCHEMA_OWNER_PASSWORD>changeMe</WQP_SCHEMA_OWNER_PASSWORD>
-                                    <WQP_READ_ONLY_USERNAME>wqp_user</WQP_READ_ONLY_USERNAME>
-                                    <WQP_READ_ONLY_PASSWORD>changeMe</WQP_READ_ONLY_PASSWORD>
-                                    <ARS_DATABASE_ADDRESS>127.0.0.1</ARS_DATABASE_ADDRESS>
-                                    <ARS_DATABASE_NAME>wqp_db</ARS_DATABASE_NAME>
-                                    <ARS_DB_OWNER_USERNAME>wqp_core</ARS_DB_OWNER_USERNAME>
-                                    <ARS_DB_OWNER_PASSWORD>changeMe</ARS_DB_OWNER_PASSWORD>
-                                    <ARS_SCHEMA_NAME>ars</ARS_SCHEMA_NAME>
-                                    <ARS_SCHEMA_OWNER_USERNAME>ars_owner</ARS_SCHEMA_OWNER_USERNAME>
-                                    <ARS_SCHEMA_OWNER_PASSWORD>changeMe</ARS_SCHEMA_OWNER_PASSWORD>
-                                    <BIODATA_DATABASE_ADDRESS>127.0.0.1</BIODATA_DATABASE_ADDRESS>
-                                    <BIODATA_DATABASE_NAME>wqp_db</BIODATA_DATABASE_NAME>
-                                    <BIODATA_DB_OWNER_USERNAME>wqp_core</BIODATA_DB_OWNER_USERNAME>
-                                    <BIODATA_DB_OWNER_PASSWORD>changeMe</BIODATA_DB_OWNER_PASSWORD>
-                                    <BIODATA_SCHEMA_NAME>biodata</BIODATA_SCHEMA_NAME>
-                                    <BIODATA_SCHEMA_OWNER_USERNAME>biodata_owner</BIODATA_SCHEMA_OWNER_USERNAME>
-                                    <BIODATA_SCHEMA_OWNER_PASSWORD>changeMe</BIODATA_SCHEMA_OWNER_PASSWORD>
-                                    <NWIS_DATABASE_ADDRESS>127.0.0.1</NWIS_DATABASE_ADDRESS>
-                                    <NWIS_DATABASE_NAME>wqp_db</NWIS_DATABASE_NAME>
-                                    <NWIS_DB_OWNER_USERNAME>wqp_core</NWIS_DB_OWNER_USERNAME>
-                                    <NWIS_DB_OWNER_PASSWORD>changeMe</NWIS_DB_OWNER_PASSWORD>
-                                    <NWIS_SCHEMA_NAME>nwis</NWIS_SCHEMA_NAME>
-                                    <NWIS_SCHEMA_OWNER_USERNAME>nwis_ws_star</NWIS_SCHEMA_OWNER_USERNAME>
-                                    <NWIS_SCHEMA_OWNER_PASSWORD>changeMe</NWIS_SCHEMA_OWNER_PASSWORD>
-                                    <EPA_DATABASE_ADDRESS>127.0.0.1</EPA_DATABASE_ADDRESS>
-                                    <EPA_DATABASE_NAME>wqp_db</EPA_DATABASE_NAME>
-                                    <EPA_DB_OWNER_USERNAME>wqp_core</EPA_DB_OWNER_USERNAME>
-                                    <EPA_DB_OWNER_PASSWORD>changeMe</EPA_DB_OWNER_PASSWORD>
-                                    <EPA_SCHEMA_OWNER_USERNAME>epa_owner</EPA_SCHEMA_OWNER_USERNAME>
-                                    <EPA_SCHEMA_OWNER_PASSWORD>changeMe</EPA_SCHEMA_OWNER_PASSWORD>
-                                    <WQX_SCHEMA_NAME>wqx</WQX_SCHEMA_NAME>
-                                    <WQX_DUMP_SCHEMA_NAME>wqx_dump</WQX_DUMP_SCHEMA_NAME>
-                                    <STORETW_SCHEMA_NAME>storetw</STORETW_SCHEMA_NAME>
-                                    <STORETW_DUMP_SCHEMA_NAME>storetw_dump</STORETW_DUMP_SCHEMA_NAME>
-                                </env>
                                 <wait>
                                     <time>150000</time>
                                     <log>(?s)PostgreSQL init process complete; ready for start up.*database system is ready to accept connections</log>

--- a/src/main/resources/sql/monitoringLocation/monitoringLocation.sql
+++ b/src/main/resources/sql/monitoringLocation/monitoringLocation.sql
@@ -73,4 +73,5 @@ select 3 data_source_id,
        left join storetw_dump."LU_MAD_VDATUM" lu_mad_vdatum
          on "FK_MAD_VDATUM" = lu_mad_vdatum."PK_ISN"
  where fa_station."LOCATION_POINT_TYPE" = '*POINT OF RECORD' and
+       fa_station."SOURCE_SYSTEM" is null and
        fa_station."ORGANIZATION_ID" not in (select org_id from storetw.storetw_transition)

--- a/src/main/resources/sql/monitoringLocation/monitoringLocation.sql
+++ b/src/main/resources/sql/monitoringLocation/monitoringLocation.sql
@@ -24,11 +24,11 @@ insert
 select 3 data_source_id,
        'STORET' data_source,
        fa_station."PK_ISN" station_id,
-       fa_station."ORGANIZATION_ID" || '-' || fa_station."STATION_ID" site_id,
+       coalesce(fa_station."ORGANIZATION_ID", '') || '-' || coalesce(fa_station."STATION_ID", '') site_id,
        fa_station."ORGANIZATION_ID" organization,
        fa_station."STATION_GROUP_TYPE" site_type,
        fa_station."GENERATED_HUC" huc,
-       di_geo_state."COUNTRY_CODE" || ':' || rtrim(di_geo_state."FIPS_STATE_CODE") || ':' || di_geo_county."FIPS_COUNTY_CODE" governmental_unit_code,
+       coalesce(di_geo_state."COUNTRY_CODE", '') || ':' || coalesce(lpad(rtrim(di_geo_state."FIPS_STATE_CODE"), 2, '0'), '') || ':' || coalesce(di_geo_county."FIPS_COUNTY_CODE", '') governmental_unit_code,
        case
          when fa_station."LONGITUDE" is not null and fa_station."LATITUDE" is not null
            then st_transform(st_SetSrid(st_MakePoint(fa_station."LONGITUDE", fa_station."LATITUDE"), coalesce(hdatum_to_srid.srid, 4269)),  4269)


### PR DESCRIPTION
This is the only query that did not have the source_system is null check. I believe it the be the reason for the 'not in' portion of the updateWqxMonitoringLocationLocalStoretw.sql query in the etl-epa and the cause root cause of that step failing. Adding this only removed results for 174 stations in result_no_source. Those results never made it into WQP from this source (storetw) (ORGANIZATION = 'USACOEND').