### PR TITLE
WQP-1592 (Drop "unlogged" keyword from all WQP tables)

### DIFF
--- a/src/main/resources/db/changelog/epa/tables/hdatumToSrid/changeLog.yml
+++ b/src/main/resources/db/changelog/epa/tables/hdatumToSrid/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${STORETW_SCHEMA_NAME}.hdatum_to_srid"
+      id: "create.table.${STORETW_SCHEMA_NAME}.hdatum_to_srid.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/src/main/resources/db/changelog/epa/tables/hdatumToSrid/hdatumToSrid.sql
+++ b/src/main/resources/db/changelog/epa/tables/hdatumToSrid/hdatumToSrid.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${STORETW_SCHEMA_NAME}.hdatum_to_srid
+create table if not exists ${STORETW_SCHEMA_NAME}.hdatum_to_srid
 (fk_mad_hdatum                  numeric
 ,srid                           integer
 )


### PR DESCRIPTION
   Removed unlogged from hdatumToSrid.sql
   Update d to version v2 for the create changeLog

The approach taken here is that, since hdatum_to_srid is a regular table
with no partitions (small, 16K currently on test), the setting
of the table to logged can be done separately using a single
sql command existing databases. Going forward when this is
used to create the table, the table will be in the desired state.
No need to maintain a separate lquidbase script.